### PR TITLE
Update messageservice.ts

### DIFF
--- a/src/app/components/api/messageservice.ts
+++ b/src/app/components/api/messageservice.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Message } from './message';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class MessageService {
     
     private messageSource = new Subject<Message|Message[]>();


### PR DESCRIPTION
As i understand the PrimeNG MessageService is a nice example for a singleton service and should therefore use the `providedIn: 'root'` property.

More details: https://angular.io/guide/singleton-services#singleton-services

###Defect Fixes
N/A

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.